### PR TITLE
Disable removing newlines

### DIFF
--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -25,10 +25,6 @@
       The original HTML with the addition of anchors inside of all of the h1-h6 headings.
   {% endcomment %}
 
-<!-- We need a newline character, so the lack of indentation here is important -->
-{% capture new_line %}
-{% endcapture %}
-
   {% assign minHeader = include.h_min | default: 1 %}
   {% assign maxHeader = include.h_max | default: 6 %}
   {% assign beforeHeading = include.beforeHeading %}
@@ -92,6 +88,6 @@
         {{ include.bodySuffix }}
       </h{{ _workspace | last }}
     {% endcapture %}
-    {% capture edited_headings %}{{ edited_headings }}{{ new_heading | replace: '  ', '' | replace: new_line, '' }}{{ new_line }}{% endcapture %}
+    {% capture edited_headings %}{{ edited_headings }}{{ new_heading }}{% endcapture %}
   {% endfor %}
 {% endcapture %}{% assign headingsWorkspace = '' %}{{ edited_headings | strip }}

--- a/_tests/contentWithCodeSnippet.md
+++ b/_tests/contentWithCodeSnippet.md
@@ -1,0 +1,36 @@
+---
+# See https://github.com/allejo/jekyll-anchor-headings/pull/8
+---
+
+{% capture markdown %}
+A paragraph with dummy content
+
+## Code Sample
+
+Here is a sample Python snippet:
+
+```python
+def F(n):
+    if n == 0: return 0
+    elif n == 1: return 1
+    else: return F(n - 1) + F(n - 2)
+```
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+<div>
+{% include anchor_headings.html html=text %}
+</div>
+
+<!-- /// -->
+
+<div>
+    <p>A paragraph with dummy content</p>
+    <h2 id="code-sample">Code Sample <a href="#code-sample"></a></h2>
+    <p>Here is a sample Python snippet:</p>
+    <div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="k">def</span> <span class="nf">F</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
+    <span class="k">if</span> <span class="n">n</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span> <span class="k">return</span> <span class="mi">0</span>
+    <span class="k">elif</span> <span class="n">n</span> <span class="o">==</span> <span class="mi">1</span><span class="p">:</span> <span class="k">return</span> <span class="mi">1</span>
+    <span class="k">else</span><span class="p">:</span> <span class="k">return</span> <span class="n">F</span><span class="p">(</span><span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="p">)</span> <span class="o">+</span> <span class="n">F</span><span class="p">(</span><span class="n">n</span> <span class="o">-</span> <span class="mi">2</span><span class="p">)</span>
+</code></pre></div></div>
+</div>


### PR DESCRIPTION
It appears to me that using this snippet is removing all newlines. This includes newlines within code tags. I think this is a bug and everything seems to render normal without removing the newlines.

Using the suggested way for this snippet, I changed `{{ content }}` to `{% include anchor_headings.html html=content %}`, which renders the following example code wrong:

```
```python
def F(n):
    if n == 0: return 0
    elif n == 1: return 1
    else: return F(n - 1) + F(n - 2)
\```
```

This is how it looks without the patch:
![before](https://i.imgur.com/hmQ2PHG.png)

And with the patch it looks fine to me:
![after](https://i.imgur.com/Pdepbij.png)

Did I overlook a case where replacements are needed? Btw thanks for creating this neat snippet. I really like it!