### PR TITLE
Add support to generate ids for headers that do not have them

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This snippet is highly customizable. Here are the available parameters to change
 | `h_max`         | int    | 6     | The maximum header level to build an anchor for; any header greater than this value will be ignored |
 | `bodyPrefix`    | string | ''    | Anything that should be inserted inside of the heading tag _before_ its anchor and content |
 | `bodySuffix`    | string | ''    | Anything that should be inserted inside of the heading tag _after_ its anchor and content |
-| `generateId`    | bool   | false | Set to true if a header without id should generate an id to use.
+| `generateId`    | bool   | false | Set to true if a header without id should generate an id to use. |
 
 <sup>*</sup> This is a required parameter
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This snippet is highly customizable. Here are the available parameters to change
 | `h_max`         | int    | 6     | The maximum header level to build an anchor for; any header greater than this value will be ignored |
 | `bodyPrefix`    | string | ''    | Anything that should be inserted inside of the heading tag _before_ its anchor and content |
 | `bodySuffix`    | string | ''    | Anything that should be inserted inside of the heading tag _after_ its anchor and content |
+| `generateId`    | bool   | false | Set to true if a header without id should generate an id to use.
 
 <sup>*</sup> This is a required parameter
 

--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -94,15 +94,15 @@
     {% assign escaped_header = header | strip_html | strip %}
 
     {% if _idWorkspace[1] %}
-    {% assign _idWorkspace = _idWorkspace[1] | split: '"' %}
-    {% assign html_id = _idWorkspace[0] %}
+      {% assign _idWorkspace = _idWorkspace[1] | split: '"' %}
+      {% assign html_id = _idWorkspace[0] %}
     {% elsif include.generateId %}
-    <!-- If the header did not have an id we create one. -->
-    {% assign html_id = escaped_header | slugify %}
-    {% if html_id == "" %}
-    {% assign html_id = false %}
-    {% endif %}
-    {% capture headerAttrs %}{{headerAttrs}} id="%html_id%"{% endcapture %}
+      <!-- If the header did not have an id we create one. -->
+      {% assign html_id = escaped_header | slugify %}
+      {% if html_id == "" %}
+        {% assign html_id = false %}
+      {% endif %}
+      {% capture headerAttrs %}{{ headerAttrs }} id="%html_id%"{% endcapture %}
     {% endif %}
 
     <!-- Build the anchor to inject for our heading -->

--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -48,6 +48,7 @@
       * h_max         (int)    :  6     - The maximum header level to build an anchor for; any header greater than this value will be ignored
       * bodyPrefix    (string) :  ''    - Anything that should be inserted inside of the heading tag _before_ its anchor and content
       * bodySuffix    (string) :  ''    - Anything that should be inserted inside of the heading tag _after_ its anchor and content
+      * generateId    (true)   :  false - Set to true if a header without id should generate an id to use.
 
     Output:
       The original HTML with the addition of anchors inside of all of the h1-h6 headings.
@@ -87,20 +88,30 @@
     {% capture _closingTag %}</h{{ headerLevel }}>{% endcapture %}
     {% assign _workspace = node | split: _closingTag %}
     {% assign _idWorkspace = _workspace[0] | split: 'id="' %}
-    {% assign _idWorkspace = _idWorkspace[1] | split: '"' %}
-    {% assign html_id = _idWorkspace[0] %}
-
+    {% assign headerAttrs = include.headerAttrs %}
     {% capture _hAttrToStrip %}{{ _workspace[0] | split: '>' | first }}>{% endcapture %}
     {% assign header = _workspace[0] | replace: _hAttrToStrip, '' %}
+    {% assign escaped_header = header | strip_html | strip %}
+
+    {% if _idWorkspace[1] %}
+    {% assign _idWorkspace = _idWorkspace[1] | split: '"' %}
+    {% assign html_id = _idWorkspace[0] %}
+    {% elsif include.generateId %}
+    <!-- If the header did not have an id we create one. -->
+    {% assign html_id = escaped_header | slugify %}
+    {% if html_id == "" %}
+    {% assign html_id = false %}
+    {% endif %}
+    {% capture headerAttrs %}{{headerAttrs}} id="%html_id%"{% endcapture %}
+    {% endif %}
 
     <!-- Build the anchor to inject for our heading -->
     {% capture anchor %}{% endcapture %}
 
     {% if html_id and headerLevel >= minHeader and headerLevel <= maxHeader %}
-      {% assign escaped_header = header | strip_html %}
 
-      {% if include.headerAttrs %}
-        {% capture _hAttrToStrip %}{{ _hAttrToStrip | split: '>' | first }} {{ include.headerAttrs | replace: '%heading%', escaped_header | replace: '%html_id%', html_id }}>{% endcapture %}
+      {% if headerAttrs %}
+        {% capture _hAttrToStrip %}{{ _hAttrToStrip | split: '>' | first }} {{ headerAttrs | replace: '%heading%', escaped_header | replace: '%html_id%', html_id }}>{% endcapture %}
       {% endif %}
 
       {% capture anchor %}href="#{{ html_id }}"{% endcapture %}

--- a/_tests/anchorsWithGeneratedIDs.html
+++ b/_tests/anchorsWithGeneratedIDs.html
@@ -1,0 +1,13 @@
+---
+# See: https://github.com/allejo/jekyll-anchor-headings/issues/1
+---
+
+{% capture text %}
+<h2>Hello world</h2>
+{% endcapture %}
+
+{% include anchor_headings.html html=text generateId=true %}
+
+<!-- /// -->
+
+<h2 id="hello-world">Hello world <a href="#hello-world"></a></h2>


### PR DESCRIPTION
As commonmark does not generate ids for its headers see,

https://github.com/github/cmark-gfm/issues/186

we need the possibility to generate them when creating anchor headings.

See #1 for a bit more detail of why this is not always wanted.