### PR TITLE
Add support for `no_anchor` class

### DIFF
--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -57,6 +57,7 @@
   {% assign minHeader = include.h_min | default: 1 %}
   {% assign maxHeader = include.h_max | default: 6 %}
   {% assign beforeHeading = include.beforeHeading %}
+  {% assign headerAttrs = include.headerAttrs %}
   {% assign nodes = include.html | split: '<h' %}
 
   {% capture edited_headings %}{% endcapture %}
@@ -87,12 +88,21 @@
 
     {% capture _closingTag %}</h{{ headerLevel }}>{% endcapture %}
     {% assign _workspace = node | split: _closingTag %}
-    {% assign _idWorkspace = _workspace[0] | split: 'id="' %}
-    {% assign headerAttrs = include.headerAttrs %}
     {% capture _hAttrToStrip %}{{ _workspace[0] | split: '>' | first }}>{% endcapture %}
     {% assign header = _workspace[0] | replace: _hAttrToStrip, '' %}
     {% assign escaped_header = header | strip_html | strip %}
 
+    {% assign _classWorkspace = _workspace[0] | split: 'class="' %}
+    {% assign _classWorkspace = _classWorkspace[1] | split: '"' %}
+    {% assign _html_class = _classWorkspace[0] %}
+
+    {% if _html_class contains "no_anchor" %}
+      {% assign skip_anchor = true %}
+    {% else %}
+      {% assign skip_anchor = false %}
+    {% endif %}
+
+    {% assign _idWorkspace = _workspace[0] | split: 'id="' %}
     {% if _idWorkspace[1] %}
       {% assign _idWorkspace = _idWorkspace[1] | split: '"' %}
       {% assign html_id = _idWorkspace[0] %}
@@ -108,8 +118,7 @@
     <!-- Build the anchor to inject for our heading -->
     {% capture anchor %}{% endcapture %}
 
-    {% if html_id and headerLevel >= minHeader and headerLevel <= maxHeader %}
-
+    {% if skip_anchor == false and html_id and headerLevel >= minHeader and headerLevel <= maxHeader %}
       {% if headerAttrs %}
         {% capture _hAttrToStrip %}{{ _hAttrToStrip | split: '>' | first }} {{ headerAttrs | replace: '%heading%', escaped_header | replace: '%html_id%', html_id }}>{% endcapture %}
       {% endif %}

--- a/_tests/excludeAnchorWithClass.html
+++ b/_tests/excludeAnchorWithClass.html
@@ -1,0 +1,23 @@
+---
+# See https://github.com/allejo/jekyll-anchor-headings/issues/33
+---
+
+{% capture markdown %}
+# Heading 1
+
+# Heading 2
+{:.no_anchor}
+{% endcapture %}
+{% assign text = markdown | markdownify %}
+
+<div>
+  {% include anchor_headings.html html=text %}
+</div>
+
+<!-- /// -->
+
+<div>
+  <h1 id="heading-1">Heading 1 <a href="#heading-1"></a></h1>
+
+  <h1 class="no_anchor" id="heading-2">Heading 2</h1>
+</div>


### PR DESCRIPTION
Respect `no_anchor` class similar to jekyll-toc's `no_toc` class. When a heading has this class, no anchor will be added to it.

Fixes #33﻿

/cc @xplosionmind