### PR TITLE
Remove leading whitespace from output template capture

### DIFF
--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -148,15 +148,15 @@
     {% endif %}
 
     {% capture new_heading %}
-      <h{{ _hAttrToStrip }}
-        {{ include.bodyPrefix }}
-        {% if beforeHeading %}
-          {{ anchor }}{{ header }}
-        {% else %}
-          {{ header }}{{ anchor }}
-        {% endif %}
-        {{ include.bodySuffix }}
-      </h{{ headerLevel }}>
+<h{{ _hAttrToStrip }}
+  {{ include.bodyPrefix }}
+  {% if beforeHeading %}
+    {{ anchor }}{{ header }}
+  {% else %}
+    {{ header }}{{ anchor }}
+  {% endif %}
+  {{ include.bodySuffix }}
+</h{{ headerLevel }}>
     {% endcapture %}
 
     <!--


### PR DESCRIPTION
The whitespace in the output template causes problems when this filter is used in an embedded fashion. Specifically, we are looping through a collection
to create a "combined view" page. This combined page is a markdown page which later gets put through the normal templates.

~~~
{% assign items = site["collection-name"] | sort: "navOrder" %}

{% for item in items %}

{% capture sectionAttr %}data-section="{{item.section}}"{% endcapture %}

{% include anchor_headings.html html=item.content headerAttrs=sectionAttr anchorClass="header-link" anchorBody="<i class=\"fa fa-link\"></i>" %}

{% endfor %}
~~~

Previously, the inner part of the for loop was simply `{{item.content}}`.

The problem comes when this is run through the Jekyll templates, the leading whitespace in the output templates gets interpreted as a blockquote. The whitespace seems 
unnecessary, and removing it like in this PR removes the issue entirely.
