### PR TITLE
Fix duplicated id attributes in headers

### DIFF
--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -106,21 +106,23 @@
     {% if _idWorkspace[1] %}
       {% assign _idWorkspace = _idWorkspace[1] | split: '"' %}
       {% assign html_id = _idWorkspace[0] %}
+      {% assign h_attrs = headerAttrs %}
     {% elsif include.generateId %}
       <!-- If the header did not have an id we create one. -->
       {% assign html_id = escaped_header | slugify %}
       {% if html_id == "" %}
         {% assign html_id = false %}
       {% endif %}
-      {% capture headerAttrs %}{{ headerAttrs }} id="%html_id%"{% endcapture %}
+      <!-- Append the generated id to other potential header attributes. -->
+      {% capture h_attrs %}{{ headerAttrs }} id="%html_id%"{% endcapture %}
     {% endif %}
 
     <!-- Build the anchor to inject for our heading -->
     {% capture anchor %}{% endcapture %}
 
     {% if skip_anchor == false and html_id and headerLevel >= minHeader and headerLevel <= maxHeader %}
-      {% if headerAttrs %}
-        {% capture _hAttrToStrip %}{{ _hAttrToStrip | split: '>' | first }} {{ headerAttrs | replace: '%heading%', escaped_header | replace: '%html_id%', html_id }}>{% endcapture %}
+      {% if h_attrs %}
+        {% capture _hAttrToStrip %}{{ _hAttrToStrip | split: '>' | first }} {{ h_attrs | strip | replace: '%heading%', escaped_header | replace: '%html_id%', html_id }}>{% endcapture %}
       {% endif %}
 
       {% capture anchor %}href="#{{ html_id }}"{% endcapture %}


### PR DESCRIPTION
Nice work, so slick to have it JavaScript-free! The duplicated ids technically don't bother modern browsers, but it feels nicer if we only output what is necessary, right? 🤓